### PR TITLE
Removed break tags from snippets

### DIFF
--- a/src/Resources/app/administration/src/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/snippet/de-DE.json
@@ -10,12 +10,12 @@
                 "title": "Zwei-Faktor-Authentifizierung",
                 "enabled": {
                     "title": "Zwei-Faktor-Authentifizierung ist aktiv",
-                    "description": "Glückwunsch, dein Account ist sicher!<br/>Um 2FA zu deaktivieren klicke auf den nachstehenden Button.",
+                    "description": "Glückwunsch, dein Account ist sicher! Um 2FA zu deaktivieren klicke auf den nachstehenden Button.",
                     "disable": "2FA deaktivieren"
                 },
                 "not-enabled": {
                     "title": "Zwei-Faktor-Authentifizierung ist inaktiv",
-                    "description": "Zwei-Faktor-Authentifizierung ist inaktiv!<br/>Zum Aktivieren klicke auf den nachstehenden Button.",
+                    "description": "Zwei-Faktor-Authentifizierung ist inaktiv! Zum Aktivieren klicke auf den nachstehenden Button.",
                     "get-started": "2FA aktivieren"
                 },
                 "generating": {

--- a/src/Resources/app/administration/src/snippet/en-GB.json
+++ b/src/Resources/app/administration/src/snippet/en-GB.json
@@ -10,7 +10,7 @@
                 "title": "Two factor authentication",
                 "enabled": {
                     "title": "Two factor authentication is enabled",
-                    "description": "Congrats! You're secure!<br />To disable 2FA for your account, click the button below.",
+                    "description": "Congrats! You're secure! To disable 2FA for your account, click the button below.",
                     "disable": "Disable 2FA"
                 },
                 "not-enabled": {

--- a/src/Resources/app/administration/src/snippet/fr-FR.json
+++ b/src/Resources/app/administration/src/snippet/fr-FR.json
@@ -10,7 +10,7 @@
                 "title": "Authentification à deux facteurs (2FA)",
                 "enabled": {
                     "title": "L'authentification à deux facteurs est activée",
-                    "description": "Félicitations! Vous êtes en sécurité!<br />Pour désactiver 2FA pour votre compte, cliquez sur le bouton ci-dessous.",
+                    "description": "Félicitations! Vous êtes en sécurité! Pour désactiver 2FA pour votre compte, cliquez sur le bouton ci-dessous.",
                     "disable": "Désactiver 2FA"
                 },
                 "not-enabled": {

--- a/src/Resources/app/administration/src/snippet/nl-NL.json
+++ b/src/Resources/app/administration/src/snippet/nl-NL.json
@@ -10,7 +10,7 @@
                 "title": "Twee-factorauthenticatie",
                 "enabled": {
                     "title": "Twee-factorauthenticatie is ingeschakeld",
-                    "description": "Proficiat! Je account is veilig!<br />Klik op onderstaande knop om 2FA uit te zetten.",
+                    "description": "Proficiat! Je account is veilig! Klik op onderstaande knop om 2FA uit te zetten.",
                     "disable": "Zet 2FA uit"
                 },
                 "not-enabled": {


### PR DESCRIPTION
I removed the `<br />` tags from the snippets. They don't render anyway and show faulty in the administration:
![image](https://user-images.githubusercontent.com/6866325/96367097-1b693b00-114c-11eb-9e7c-56c322d0c959.png)
