### PR TITLE
fix: use correct paths for widgets to have correct storefront language

### DIFF
--- a/src/Controller/TwoFactorAuthenticationController.php
+++ b/src/Controller/TwoFactorAuthenticationController.php
@@ -63,7 +63,7 @@ class TwoFactorAuthenticationController extends StorefrontController
     }
 
     /**
-     * @Route("/rl-2fa/profile/setup", name="rl-2fa.profile.setup", methods={"GET"}, defaults={"XmlHttpRequest"=true}))
+     * @Route("/rl-2fa/profile/setup", name="widgets.rl-2fa.profile.setup", methods={"GET"}, defaults={"XmlHttpRequest"=true}))
      */
     public function profileSetup(Request $request, SalesChannelContext $salesChannelContext): Response
     {
@@ -98,7 +98,7 @@ class TwoFactorAuthenticationController extends StorefrontController
     }
 
     /**
-     * @Route("/rl-2fa/profile/disable", name="rl-2fa.profile.disable", methods={"GET"}, defaults={"XmlHttpRequest"=true}))
+     * @Route("/rl-2fa/profile/disable", name="widgets.rl-2fa.profile.disable", methods={"GET"}, defaults={"XmlHttpRequest"=true}))
      */
     public function profileDisable(Request $request, SalesChannelContext $salesChannelContext): Response
     {
@@ -112,7 +112,7 @@ class TwoFactorAuthenticationController extends StorefrontController
     }
 
     /**
-     * @Route("/rl-2fa/profile/disable", name="rl-2fa.profile.disable.post", methods={"POST"}, defaults={"XmlHttpRequest"=true}))
+     * @Route("/rl-2fa/profile/disable", name="widgets.rl-2fa.profile.disable.post", methods={"POST"}, defaults={"XmlHttpRequest"=true}))
      */
     public function profileDisablePost(Request $request, SalesChannelContext $salesChannelContext): Response
     {
@@ -159,7 +159,7 @@ class TwoFactorAuthenticationController extends StorefrontController
     }
 
     /**
-     * @Route("/rl-2fa/profile/validate", name="rl-2fa.profile.validate", methods={"POST"}, defaults={"XmlHttpRequest"=true}))
+     * @Route("/rl-2fa/profile/validate", name="widgets.rl-2fa.profile.validate", methods={"POST"}, defaults={"XmlHttpRequest"=true}))
      */
     public function validateSecret(Request $request, SalesChannelContext $salesChannelContext): Response
     {

--- a/src/Resources/views/storefront/page/account/profile/2fa/disable.html.twig
+++ b/src/Resources/views/storefront/page/account/profile/2fa/disable.html.twig
@@ -6,7 +6,7 @@
     </p>
 
     <form method="POST"
-          action="{{ url('rl-2fa.profile.disable.post') }}">
+          action="{{ url('widgets.rl-2fa.profile.disable.post') }}">
         <p>
             {% block page_account_profile_2fa_disable_input %}
             <input type="password"
@@ -18,7 +18,7 @@
             {% endblock %}
         </p>
 
-        {{ sw_csrf('rl-2fa.profile.disable.post') }}
+        {{ sw_csrf('widgets.rl-2fa.profile.disable.post') }}
 
         {% block page_account_profile_2fa_disable_button %}
             <button type="submit" class="account-profile-2fa-setup-verify btn btn-primary btn-block">

--- a/src/Resources/views/storefront/page/account/profile/2fa/setup.html.twig
+++ b/src/Resources/views/storefront/page/account/profile/2fa/setup.html.twig
@@ -22,7 +22,7 @@
     {% endblock %}
 
     {% block page_account_profile_2fa_setup_step2 %}
-        <div class="rl-2fa-setup-step" data-rl2fa-verification-plugin="true" data-rl2fa-verification-plugin-options='{"verificationUrl": "{{ url('rl-2fa.profile.validate') }}"}'>
+        <div class="rl-2fa-setup-step" data-rl2fa-verification-plugin="true" data-rl2fa-verification-plugin-options='{"verificationUrl": "{{ url('widgets.rl-2fa.profile.validate') }}"}'>
             {% block page_account_profile_2fa_setup_step2_title %}
                 <strong class="rl-2fa-setup-step--title">{{ "rl-2fa.account.setup.step-2"|trans|sw_sanitize }}</strong>
             {% endblock %}
@@ -50,7 +50,7 @@
 
                 <input type="hidden" name="otpSecret" value="{{ secret }}">
 
-                {{ sw_csrf('rl-2fa.profile.validate') }}
+                {{ sw_csrf('widgets.rl-2fa.profile.validate') }}
 
                 {% block page_account_profile_2fa_setup_step2_button %}
                     <button class="account-profile-2fa-setup-verify btn btn-primary btn-block">

--- a/src/Resources/views/storefront/page/account/profile/index.html.twig
+++ b/src/Resources/views/storefront/page/account/profile/index.html.twig
@@ -23,7 +23,7 @@
                                     <button type="submit"
                                             class="account-profile-2fa-start-setup btn btn-primary"
                                             data-toggle="modal"
-                                            data-url="{{ path('rl-2fa.profile.setup') }}"
+                                            data-url="{{ path('widgets.rl-2fa.profile.setup') }}"
                                             title="{{ "rl-2fa.account.start-setup"|trans|striptags }}">
                                         {{ "rl-2fa.account.start-setup"|trans|sw_sanitize }}
                                     </button>
@@ -38,7 +38,7 @@
                                     <button type="submit"
                                             class="account-profile-2fa-start-setup btn btn-primary"
                                             data-toggle="modal"
-                                            data-url="{{ path('rl-2fa.profile.disable') }}"
+                                            data-url="{{ path('widgets.rl-2fa.profile.disable') }}"
                                             title="{{ "rl-2fa.account.disable-2fa"|trans|striptags }}">
                                         {{ "rl-2fa.account.disable-2fa"|trans|striptags }}
                                     </button>


### PR DESCRIPTION
The translation is always the default language, because of this:
https://github.com/shopware/platform/blob/78afb0eb4088701c970d50c314d3ec53186fbd11/src/Storefront/Framework/Routing/Router.php#L210