### PR TITLE
Fix administration asset path

### DIFF
--- a/src/Resources/views/administration/index.html.twig
+++ b/src/Resources/views/administration/index.html.twig
@@ -54,7 +54,7 @@
 
         return this.initializeLoginInitializer()
             .then(() => this.injectPlugin({
-                js: "/bundles/runelaenentwofactorauth/administration/js/rune-laenen-two-factor-auth.js"
+                js: "{{ asset('administration/js/rune-laenen-two-factor-auth.js', '@RuneLaenenTwoFactorAuth') }}"
             }))
             .then(() => {
                 if (!this.view) {


### PR DESCRIPTION
**Problem**
Currently the js asset path in the administration is hard coded and will not work if Shopware is configured to use a CDN or is running in a subfolder.

**Fix**
Use the `asset` twig function instead to generate the asset path considering the system configuration.