### PR TITLE
Use sw_extends to extend admin twig template

### DIFF
--- a/src/Resources/views/administration/index.html.twig
+++ b/src/Resources/views/administration/index.html.twig
@@ -1,4 +1,4 @@
-{% extends '@Administration/administration/index.html.twig' %}
+{% sw_extends '@Administration/administration/index.html.twig' %}
 
 {% block administration_login_scripts %}
     <script nonce="{{ cspNonce }}">


### PR DESCRIPTION
Hi,

thank you for this plugin!

This pull request replaces the usage of Twig's default `extends` tag with Shopware's `sw_extends` in the `administration/index.html.twig` template. This allows other plugins to also extend this template, since `sw_extends` supports multi-inheritance, while `extends` does not. The overwritten storefront templates already use `sw_extends`

Best
Florian